### PR TITLE
Patch fcntlmodule for Solaris

### DIFF
--- a/patches/3.12/06-solaris-fcntlmodule.patch
+++ b/patches/3.12/06-solaris-fcntlmodule.patch
@@ -1,5 +1,5 @@
 diff --git a/Modules/fcntlmodule.c b/Modules/fcntlmodule.c
-index 2bca40213c6..b16dfd8b534 100644
+index 2bca40213c6..59dab31bc40 100644
 --- a/Modules/fcntlmodule.c
 +++ b/Modules/fcntlmodule.c
 @@ -628,6 +628,15 @@ all_ins(PyObject* m)
@@ -8,10 +8,10 @@ index 2bca40213c6..b16dfd8b534 100644
  #ifdef HAVE_STROPTS_H
 +
 +#if defined(sun) || defined(__sun)
-+  #ifdef STR
-+    const long STR_val = STR;
-+    #undef STR
-+    #define STR STR_val
++  #ifndef STR
++    /* for some reason, the preprocessor does not resolve this symbol */
++    /* from /usr/include/sys/stropts.h on Solaris 11 */
++    #define STR ('S'<<8)
 +  #endif
 +#endif
 +

--- a/patches/3.12/06-solaris-fcntlmodule.patch
+++ b/patches/3.12/06-solaris-fcntlmodule.patch
@@ -1,19 +1,17 @@
 diff --git a/Modules/fcntlmodule.c b/Modules/fcntlmodule.c
-index 2bca40213c6..a4e567bab9b 100644
+index 2bca40213c6..b16dfd8b534 100644
 --- a/Modules/fcntlmodule.c
 +++ b/Modules/fcntlmodule.c
-@@ -628,6 +628,17 @@ all_ins(PyObject* m)
+@@ -628,6 +628,15 @@ all_ins(PyObject* m)
  #endif
  
  #ifdef HAVE_STROPTS_H
 +
 +#if defined(sun) || defined(__sun)
 +  #ifdef STR
-+    #define _STR_tmp STR
++    const long STR_val = STR;
 +    #undef STR
-+    const long STR = _STR_tmp;
-+    #define STR _STR_tmp
-+    #undef _STR_tmp
++    #define STR STR_val
 +  #endif
 +#endif
 +

--- a/patches/3.12/06-solaris-fcntlmodule.patch
+++ b/patches/3.12/06-solaris-fcntlmodule.patch
@@ -1,0 +1,22 @@
+diff --git a/Modules/fcntlmodule.c b/Modules/fcntlmodule.c
+index 2bca40213c6..a4e567bab9b 100644
+--- a/Modules/fcntlmodule.c
++++ b/Modules/fcntlmodule.c
+@@ -628,6 +628,17 @@ all_ins(PyObject* m)
+ #endif
+ 
+ #ifdef HAVE_STROPTS_H
++
++#if defined(sun) || defined(__sun)
++  #ifdef STR
++    #define _STR_tmp STR
++    #undef STR
++    const long STR = _STR_tmp;
++    #define STR _STR_tmp
++    #undef _STR_tmp
++  #endif
++#endif
++
+     /* Unix 98 guarantees that these are in stropts.h. */
+     if (PyModule_AddIntMacro(m, I_PUSH)) return -1;
+     if (PyModule_AddIntMacro(m, I_POP)) return -1;


### PR DESCRIPTION
The STR macro from stropts.h is not expanded correctly, so define it explicitly.