### PR TITLE
Fix breakage when used as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -905,7 +905,7 @@ if(BUILD_TESTING)
     function(add_cmakescript_test testname script)
       add_test(cmake_${testname}_test ${CMAKE_COMMAND}
         -DTEST_${testname}:BOOL=ON
-        -P ${CMAKE_SOURCE_DIR}/${script})
+        -P ${PROJECT_SOURCE_DIR}/${script})
       set_tests_properties(cmake_${testname}_test PROPERTIES
         LABELS CMake
         PASS_REGULAR_EXPRESSION "SUCCESS")

--- a/cmake/CheckEndianness.cmake
+++ b/cmake/CheckEndianness.cmake
@@ -5,8 +5,8 @@ macro(define_python_endianness_macros)
 
   # Test for float endianness
   try_run(RESULT_VAR COMPILE_VAR
-    ${CMAKE_BINARY_DIR}/check_float_endianness_result
-    ${CMAKE_SOURCE_DIR}/cmake/check_float_endianness.c
+    ${CMAKE_CURRENT_BINARY_DIR}/check_float_endianness_result
+    ${PROJECT_SOURCE_DIR}/cmake/check_float_endianness.c
   )
   if(RESULT_VAR EQUAL 1)
     message(STATUS "System uses big-endian floating point format")

--- a/cmake/lib/CMakeLists.txt
+++ b/cmake/lib/CMakeLists.txt
@@ -43,6 +43,15 @@ endif()
 
 # Generate grammar tables in install directory
 # XXX Should a custom target be added to generate file at built time ?
+set(lib2to3code "")
+if(PY_VERSION VERSION_LESS "3.13")
+  set(lib2to3code "
+  execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
+    \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/Grammar.txt)
+  execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
+    \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/PatternGrammar.txt)
+")
+endif()
 install(CODE "find_program(
   PYTHON_EXECUTABLE python
   HINTS \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${BIN_INSTALL_DIR}
@@ -55,8 +64,5 @@ if(UNIX)
   endif()
   set(wrapper env \${_envvar}=\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${LIBPYTHON_LIBDIR})
 endif()
-execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
-  \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/Grammar.txt)
-execute_process(COMMAND \${wrapper} \${PYTHON_EXECUTABLE} -m lib2to3.pgen2.driver
-  \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/${PYTHONHOME}/lib2to3/PatternGrammar.txt)
+${lib2to3code}
 ")

--- a/cmake/tools/CMakeLists.txt
+++ b/cmake/tools/CMakeLists.txt
@@ -7,7 +7,9 @@ list(APPEND files
 endif()
 
 foreach(file IN LISTS files)
-  get_filename_component(path ${file} PATH)
-  file(COPY ${SRC_DIR}/${file} DESTINATION ${PROJECT_BINARY_DIR}/${LIBDIR}/${path})
-  install(FILES ${SRC_DIR}/${file} DESTINATION ${LIBDIR}/${path})
+  if (EXISTS "${SRC_DIR}/${file}")
+    get_filename_component(path ${file} PATH)
+    file(COPY ${SRC_DIR}/${file} DESTINATION ${PROJECT_BINARY_DIR}/${LIBDIR}/${path})
+    install(FILES ${SRC_DIR}/${file} DESTINATION ${LIBDIR}/${path})
+  endif()
 endforeach()


### PR DESCRIPTION
Some of the scripts used `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` directly, which are relative to the root of the configure run, not to any particular project within it, so tend to break when taken as a subproject. This PR changes them to their preferred relative counterparts.

Also a few additional drive-by fixes:

- fixed an issue where the build would fail completely if `Tools/scripts/run_tests.py` was not found
- removed the generated install-time code for the `lib2to3` module for python >= 3.13, since it was removed