### PR TITLE
fix some unconditional try_run() calls

### DIFF
--- a/cmake/CheckEndianness.cmake
+++ b/cmake/CheckEndianness.cmake
@@ -1,18 +1,20 @@
 include(TestBigEndian)
 
 macro(define_python_endianness_macros)
-  TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
+  if (NOT DEFINED FLOAT_WORDS_BIGENDIAN)
+    TEST_BIG_ENDIAN(WORDS_BIGENDIAN)
 
-  # Test for float endianness
-  try_run(RESULT_VAR COMPILE_VAR
-    ${CMAKE_CURRENT_BINARY_DIR}/check_float_endianness_result
-    ${PROJECT_SOURCE_DIR}/cmake/check_float_endianness.c
-  )
-  if(RESULT_VAR EQUAL 1)
-    message(STATUS "System uses big-endian floating point format")
-    set(FLOAT_WORDS_BIGENDIAN 1)
-  else()
-    message(STATUS "System uses little-endian floating point format")
-    set(FLOAT_WORDS_BIGENDIAN 0)
+    # Test for float endianness
+    try_run(FLOAT_WORDS_BIGENDIAN_RESULT_VAR FLOAT_WORDS_BIGENDIAN_COMPILE_VAR
+      ${CMAKE_CURRENT_BINARY_DIR}/check_float_endianness_result
+      ${PROJECT_SOURCE_DIR}/cmake/check_float_endianness.c
+    )
+    if(FLOAT_WORDS_BIGENDIAN_RESULT_VAR EQUAL 1)
+      message(STATUS "System uses big-endian floating point format")
+      set(FLOAT_WORDS_BIGENDIAN 1)
+    else()
+      message(STATUS "System uses little-endian floating point format")
+      set(FLOAT_WORDS_BIGENDIAN 0)
+    endif()
   endif()
 endmacro()

--- a/cmake/ConfigureChecks.cmake
+++ b/cmake/ConfigureChecks.cmake
@@ -212,12 +212,14 @@ if(WITH_FREE_THREADING AND PY_VERSION VERSION_GREATER_EQUAL "3.13")
 endif()
 message(STATUS "${_msg} - ${ABIFLAGS}")
 
-set(_msg "Checking PLATFORM_TRIPLET")
-try_run(PLATFORM_RUN PLATFORM_COMPILE
-        ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/platform.c
-        RUN_OUTPUT_VARIABLE PLATFORM_TRIPLET)
-if(NOT PLATFORM_COMPILE)
-  message(FATAL_ERROR "We could not determine the platform. Please clean the ${CMAKE_PROJECT_NAME} environment and try again...")
+if(NOT DEFINED PLATFORM_TRIPLET)
+  set(_msg "Checking PLATFORM_TRIPLET")
+  try_run(PLATFORM_RUN PLATFORM_COMPILE
+          ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}/cmake/platform.c
+          RUN_OUTPUT_VARIABLE PLATFORM_TRIPLET)
+  if(NOT PLATFORM_COMPILE)
+    message(FATAL_ERROR "We could not determine the platform. Please clean the ${CMAKE_PROJECT_NAME} environment and try again...")
+  endif()
 endif()
 message(STATUS "${_msg} - ${PLATFORM_TRIPLET}")
 set(_msg "Checking SOABI")


### PR DESCRIPTION
Some of the calls to `try_run()` were unconditional, with no preemptive checks for their final result being already defined.

This breaks cross-compilation contexts where the host architecture and the target architecture are incompatible, because cmake is unable to run the test executable to retrieve the result.

Allowing the value to be precomputed and defined via `-DXXX=Y` avoids this problem.