### PR TITLE
cosmo: resolve stdlib prefix from embedded /zip store for standalone builds

### DIFF
--- a/patches/3.10/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.10/portable/01-getpath-portable-prefix.patch
@@ -7,7 +7,7 @@ index 5dbe57c950..47b67e4ccb 100644
  #include <string.h>
  
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +char _portable_python_path_sep = '/';
 +#else
 +char _portable_python_path_sep = '\\';

--- a/patches/3.10/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.10/portable/01-getpath-portable-prefix.patch
@@ -2,7 +2,7 @@ diff --git a/Modules/getpath.c b/Modules/getpath.c
 index 5dbe57c950..47b67e4ccb 100644
 --- a/Modules/getpath.c
 +++ b/Modules/getpath.c
-@@ -9,6 +9,120 @@
+@@ -9,6 +9,171 @@
  #include <sys/types.h>
  #include <string.h>
  
@@ -105,7 +105,58 @@ index 5dbe57c950..47b67e4ccb 100644
 +
 +#endif
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#ifdef __COSMOPOLITAN__
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <limits.h>
++#include <errno.h>
++#include <pthread.h>
++#include <cosmo.h>
++
++pthread_mutex_t portable_python_prefix_mutex = PTHREAD_MUTEX_INITIALIZER;
++char portable_python_prefix[PATH_MAX] = {0};
++
++static char* portable_python_get_install_prefix() {
++    pthread_mutex_lock(&portable_python_prefix_mutex);
++
++    if (portable_python_prefix[0] != '\0') {
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Standalone build: the stdlib is bundled into this executable's
++    // own zip store, which Cosmopolitan mounts at /zip.
++    if (access("/zip/lib", F_OK) == 0) {
++        strcpy(portable_python_prefix, "/zip");
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Directory-mode build: the stdlib sits in ../lib relative to
++    // this executable on disk. /proc/self/exe isn't available on every
++    // platform Cosmopolitan runs on, so use the native APE accessor
++    // instead of readlink().
++    char *exe = GetProgramExecutableName();
++    if (exe == NULL) {
++        fprintf(stderr, "Error getting executable path\n");
++        exit(EXIT_FAILURE);
++    }
++    strncpy(portable_python_prefix, exe, PATH_MAX - 1);
++    portable_python_prefix[PATH_MAX - 1] = '\0';
++
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // bin directory
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // root directory
++
++    pthread_mutex_unlock(&portable_python_prefix_mutex);
++    return portable_python_prefix;
++}
++
++#endif
++
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +
 +#ifdef PREFIX
 +# undef PREFIX

--- a/patches/3.10/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.10/portable/01-getpath-portable-prefix.patch
@@ -16,7 +16,7 @@ index 5dbe57c950..47b67e4ccb 100644
 +static void _portable_python_trim_to_parent_directory(char* path) {
 +    char* last_slash = strrchr(path, _portable_python_path_sep);
 +    if (last_slash == NULL) {
-+        fprintf(stderr, "Invalid path: No parent directory found\n");
++        fprintf(stderr, "Invalid path: No parent directory found: %s\n", path);
 +        exit(EXIT_FAILURE);
 +    }
 +

--- a/patches/3.11/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.11/portable/01-getpath-portable-prefix.patch
@@ -7,7 +7,7 @@ index 5dbe57c950..47b67e4ccb 100644
  #include <string.h>
  
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +char _portable_python_path_sep = '/';
 +#else
 +char _portable_python_path_sep = '\\';

--- a/patches/3.11/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.11/portable/01-getpath-portable-prefix.patch
@@ -2,7 +2,7 @@ diff --git a/Modules/getpath.c b/Modules/getpath.c
 index 5dbe57c950..47b67e4ccb 100644
 --- a/Modules/getpath.c
 +++ b/Modules/getpath.c
-@@ -9,6 +9,120 @@
+@@ -9,6 +9,171 @@
  #include <sys/types.h>
  #include <string.h>
  
@@ -105,7 +105,58 @@ index 5dbe57c950..47b67e4ccb 100644
 +
 +#endif
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#ifdef __COSMOPOLITAN__
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <limits.h>
++#include <errno.h>
++#include <pthread.h>
++#include <cosmo.h>
++
++pthread_mutex_t portable_python_prefix_mutex = PTHREAD_MUTEX_INITIALIZER;
++char portable_python_prefix[PATH_MAX] = {0};
++
++static char* portable_python_get_install_prefix() {
++    pthread_mutex_lock(&portable_python_prefix_mutex);
++
++    if (portable_python_prefix[0] != '\0') {
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Standalone build: the stdlib is bundled into this executable's
++    // own zip store, which Cosmopolitan mounts at /zip.
++    if (access("/zip/lib", F_OK) == 0) {
++        strcpy(portable_python_prefix, "/zip");
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Directory-mode build: the stdlib sits in ../lib relative to
++    // this executable on disk. /proc/self/exe isn't available on every
++    // platform Cosmopolitan runs on, so use the native APE accessor
++    // instead of readlink().
++    char *exe = GetProgramExecutableName();
++    if (exe == NULL) {
++        fprintf(stderr, "Error getting executable path\n");
++        exit(EXIT_FAILURE);
++    }
++    strncpy(portable_python_prefix, exe, PATH_MAX - 1);
++    portable_python_prefix[PATH_MAX - 1] = '\0';
++
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // bin directory
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // root directory
++
++    pthread_mutex_unlock(&portable_python_prefix_mutex);
++    return portable_python_prefix;
++}
++
++#endif
++
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +
 +#ifdef PREFIX
 +# undef PREFIX

--- a/patches/3.11/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.11/portable/01-getpath-portable-prefix.patch
@@ -16,7 +16,7 @@ index 5dbe57c950..47b67e4ccb 100644
 +static void _portable_python_trim_to_parent_directory(char* path) {
 +    char* last_slash = strrchr(path, _portable_python_path_sep);
 +    if (last_slash == NULL) {
-+        fprintf(stderr, "Invalid path: No parent directory found\n");
++        fprintf(stderr, "Invalid path: No parent directory found: %s\n", path);
 +        exit(EXIT_FAILURE);
 +    }
 +

--- a/patches/3.12/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.12/portable/01-getpath-portable-prefix.patch
@@ -7,7 +7,7 @@ index 5dbe57c950..47b67e4ccb 100644
  #include <string.h>
  
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +char _portable_python_path_sep = '/';
 +#else
 +char _portable_python_path_sep = '\\';

--- a/patches/3.12/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.12/portable/01-getpath-portable-prefix.patch
@@ -2,7 +2,7 @@ diff --git a/Modules/getpath.c b/Modules/getpath.c
 index 5dbe57c950..47b67e4ccb 100644
 --- a/Modules/getpath.c
 +++ b/Modules/getpath.c
-@@ -9,6 +9,120 @@
+@@ -9,6 +9,171 @@
  #include <sys/types.h>
  #include <string.h>
  
@@ -105,7 +105,58 @@ index 5dbe57c950..47b67e4ccb 100644
 +
 +#endif
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#ifdef __COSMOPOLITAN__
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <limits.h>
++#include <errno.h>
++#include <pthread.h>
++#include <cosmo.h>
++
++pthread_mutex_t portable_python_prefix_mutex = PTHREAD_MUTEX_INITIALIZER;
++char portable_python_prefix[PATH_MAX] = {0};
++
++static char* portable_python_get_install_prefix() {
++    pthread_mutex_lock(&portable_python_prefix_mutex);
++
++    if (portable_python_prefix[0] != '\0') {
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Standalone build: the stdlib is bundled into this executable's
++    // own zip store, which Cosmopolitan mounts at /zip.
++    if (access("/zip/lib", F_OK) == 0) {
++        strcpy(portable_python_prefix, "/zip");
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Directory-mode build: the stdlib sits in ../lib relative to
++    // this executable on disk. /proc/self/exe isn't available on every
++    // platform Cosmopolitan runs on, so use the native APE accessor
++    // instead of readlink().
++    char *exe = GetProgramExecutableName();
++    if (exe == NULL) {
++        fprintf(stderr, "Error getting executable path\n");
++        exit(EXIT_FAILURE);
++    }
++    strncpy(portable_python_prefix, exe, PATH_MAX - 1);
++    portable_python_prefix[PATH_MAX - 1] = '\0';
++
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // bin directory
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // root directory
++
++    pthread_mutex_unlock(&portable_python_prefix_mutex);
++    return portable_python_prefix;
++}
++
++#endif
++
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +
 +#ifdef PREFIX
 +# undef PREFIX

--- a/patches/3.12/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.12/portable/01-getpath-portable-prefix.patch
@@ -16,7 +16,7 @@ index 5dbe57c950..47b67e4ccb 100644
 +static void _portable_python_trim_to_parent_directory(char* path) {
 +    char* last_slash = strrchr(path, _portable_python_path_sep);
 +    if (last_slash == NULL) {
-+        fprintf(stderr, "Invalid path: No parent directory found\n");
++        fprintf(stderr, "Invalid path: No parent directory found: %s\n", path);
 +        exit(EXIT_FAILURE);
 +    }
 +

--- a/patches/3.13/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.13/portable/01-getpath-portable-prefix.patch
@@ -7,7 +7,7 @@ index 5dbe57c950..47b67e4ccb 100644
  #include <string.h>
  
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +char _portable_python_path_sep = '/';
 +#else
 +char _portable_python_path_sep = '\\';

--- a/patches/3.13/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.13/portable/01-getpath-portable-prefix.patch
@@ -2,7 +2,7 @@ diff --git a/Modules/getpath.c b/Modules/getpath.c
 index 5dbe57c950..47b67e4ccb 100644
 --- a/Modules/getpath.c
 +++ b/Modules/getpath.c
-@@ -9,6 +9,120 @@
+@@ -9,6 +9,171 @@
  #include <sys/types.h>
  #include <string.h>
  
@@ -105,7 +105,58 @@ index 5dbe57c950..47b67e4ccb 100644
 +
 +#endif
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#ifdef __COSMOPOLITAN__
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <limits.h>
++#include <errno.h>
++#include <pthread.h>
++#include <cosmo.h>
++
++pthread_mutex_t portable_python_prefix_mutex = PTHREAD_MUTEX_INITIALIZER;
++char portable_python_prefix[PATH_MAX] = {0};
++
++static char* portable_python_get_install_prefix() {
++    pthread_mutex_lock(&portable_python_prefix_mutex);
++
++    if (portable_python_prefix[0] != '\0') {
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Standalone build: the stdlib is bundled into this executable's
++    // own zip store, which Cosmopolitan mounts at /zip.
++    if (access("/zip/lib", F_OK) == 0) {
++        strcpy(portable_python_prefix, "/zip");
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Directory-mode build: the stdlib sits in ../lib relative to
++    // this executable on disk. /proc/self/exe isn't available on every
++    // platform Cosmopolitan runs on, so use the native APE accessor
++    // instead of readlink().
++    char *exe = GetProgramExecutableName();
++    if (exe == NULL) {
++        fprintf(stderr, "Error getting executable path\n");
++        exit(EXIT_FAILURE);
++    }
++    strncpy(portable_python_prefix, exe, PATH_MAX - 1);
++    portable_python_prefix[PATH_MAX - 1] = '\0';
++
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // bin directory
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // root directory
++
++    pthread_mutex_unlock(&portable_python_prefix_mutex);
++    return portable_python_prefix;
++}
++
++#endif
++
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +
 +#ifdef PREFIX
 +# undef PREFIX

--- a/patches/3.13/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.13/portable/01-getpath-portable-prefix.patch
@@ -16,7 +16,7 @@ index 5dbe57c950..47b67e4ccb 100644
 +static void _portable_python_trim_to_parent_directory(char* path) {
 +    char* last_slash = strrchr(path, _portable_python_path_sep);
 +    if (last_slash == NULL) {
-+        fprintf(stderr, "Invalid path: No parent directory found\n");
++        fprintf(stderr, "Invalid path: No parent directory found: %s\n", path);
 +        exit(EXIT_FAILURE);
 +    }
 +

--- a/patches/3.9/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.9/portable/01-getpath-portable-prefix.patch
@@ -7,7 +7,7 @@ index 5dbe57c950..47b67e4ccb 100644
  #include <string.h>
  
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +char _portable_python_path_sep = '/';
 +#else
 +char _portable_python_path_sep = '\\';

--- a/patches/3.9/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.9/portable/01-getpath-portable-prefix.patch
@@ -2,7 +2,7 @@ diff --git a/Modules/getpath.c b/Modules/getpath.c
 index 5dbe57c950..47b67e4ccb 100644
 --- a/Modules/getpath.c
 +++ b/Modules/getpath.c
-@@ -9,6 +9,120 @@
+@@ -9,6 +9,171 @@
  #include <sys/types.h>
  #include <string.h>
  
@@ -105,7 +105,58 @@ index 5dbe57c950..47b67e4ccb 100644
 +
 +#endif
 +
-+#if defined(__linux__) || defined(__APPLE__)
++#ifdef __COSMOPOLITAN__
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++#include <limits.h>
++#include <errno.h>
++#include <pthread.h>
++#include <cosmo.h>
++
++pthread_mutex_t portable_python_prefix_mutex = PTHREAD_MUTEX_INITIALIZER;
++char portable_python_prefix[PATH_MAX] = {0};
++
++static char* portable_python_get_install_prefix() {
++    pthread_mutex_lock(&portable_python_prefix_mutex);
++
++    if (portable_python_prefix[0] != '\0') {
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Standalone build: the stdlib is bundled into this executable's
++    // own zip store, which Cosmopolitan mounts at /zip.
++    if (access("/zip/lib", F_OK) == 0) {
++        strcpy(portable_python_prefix, "/zip");
++        pthread_mutex_unlock(&portable_python_prefix_mutex);
++        return portable_python_prefix;
++    }
++
++    // Directory-mode build: the stdlib sits in ../lib relative to
++    // this executable on disk. /proc/self/exe isn't available on every
++    // platform Cosmopolitan runs on, so use the native APE accessor
++    // instead of readlink().
++    char *exe = GetProgramExecutableName();
++    if (exe == NULL) {
++        fprintf(stderr, "Error getting executable path\n");
++        exit(EXIT_FAILURE);
++    }
++    strncpy(portable_python_prefix, exe, PATH_MAX - 1);
++    portable_python_prefix[PATH_MAX - 1] = '\0';
++
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // bin directory
++    _portable_python_trim_to_parent_directory(portable_python_prefix); // root directory
++
++    pthread_mutex_unlock(&portable_python_prefix_mutex);
++    return portable_python_prefix;
++}
++
++#endif
++
++#if defined(__linux__) || defined(__APPLE__) || defined(__COSMOPOLITAN__)
 +
 +#ifdef PREFIX
 +# undef PREFIX

--- a/patches/3.9/portable/01-getpath-portable-prefix.patch
+++ b/patches/3.9/portable/01-getpath-portable-prefix.patch
@@ -16,7 +16,7 @@ index 5dbe57c950..47b67e4ccb 100644
 +static void _portable_python_trim_to_parent_directory(char* path) {
 +    char* last_slash = strrchr(path, _portable_python_path_sep);
 +    if (last_slash == NULL) {
-+        fprintf(stderr, "Invalid path: No parent directory found\n");
++        fprintf(stderr, "Invalid path: No parent directory found: %s\n", path);
 +        exit(EXIT_FAILURE);
 +    }
 +


### PR DESCRIPTION
Adds a `__COSMOPOLITAN__` branch to the getpath portable-prefix override (previously gated to `__linux__`/`__APPLE__`, which cosmocc defines neither of, so it never applied). Checks for a /zip/lib landmark first, which Cosmopolitan mounts from a zip store appended to the executable itself, before falling back to the existing executable-relative resolution. Uses GetProgramExecutableName() instead of reading /proc/self/exe, since that path isn't available on every host platform Cosmopolitan runs on.